### PR TITLE
Add form icon in logic form description

### DIFF
--- a/src/components/FormIcon.jsx
+++ b/src/components/FormIcon.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+const FormIcon = ({ size = 24, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    width={size}
+    height={size}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <rect x="3" y="4" width="18" height="16" rx="2" ry="2" />
+    <line x1="7" y1="8" x2="17" y2="8" />
+    <line x1="7" y1="12" x2="17" y2="12" />
+    <line x1="7" y1="16" x2="13" y2="16" />
+  </svg>
+);
+
+export default FormIcon;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Button from "../components/Button";
 import LogoutButton from "../components/LogoutButton";
 import DoubleDiagonalBanner from "../components/DoubleDiagonalBanner";
+import FormIcon from "../components/FormIcon";
 import { useNavigate } from "react-router-dom";
 
 const Container = styled.div`
@@ -99,7 +100,7 @@ const Home = () => {
             }}
           >
             <div style={{ flex: 1, minWidth: "300px" }}>
-              {/* adicionar icone de formulario  */}
+              <FormIcon size={40} style={{ color: "#4f46e5", marginBottom: "0.5rem" }} />
               <p>
                 Este formulário foi desenvolvido para avaliar o raciocínio
                 lógico do aluno, abordando questões que envolvem:


### PR DESCRIPTION
## Summary
- add `FormIcon` component with inline SVG
- display `FormIcon` in the Logic form section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cd9e81eb8832ab0927a50a0ef4b51