### PR TITLE
Add forms for math and portuguese

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,8 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import LogicForm from "./pages/LogicForm";
+import MathForm from "./pages/MathForm";
+import PortugueseForm from "./pages/PortugueseForm";
 import NotFound from "./pages/NotFound";
 import PrivateRoute from "./components/PrivateRoute";
 
@@ -34,6 +36,22 @@ const App = () => {
         element={
           <PrivateRoute>
             <LogicForm />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/forms/math"
+        element={
+          <PrivateRoute>
+            <MathForm />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/forms/portuguese"
+        element={
+          <PrivateRoute>
+            <PortugueseForm />
           </PrivateRoute>
         }
       />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -147,10 +147,102 @@ const Home = () => {
           </div>
         </li>
         <li style={{ marginBottom: "0.5rem" }}>
-          <Button disabled>Formulário de Matemática</Button>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              border: "1px solid #4f46e5cc",
+              padding: "1rem",
+              borderRadius: "8px",
+              margin: "3rem 0",
+            }}
+          >
+            <div
+              style={{
+                textAlign: "center",
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "100%",
+                gap: "1rem",
+                margin: "1rem 0",
+              }}
+            >
+              <FormIcon
+                size={40}
+                style={{ color: "#4f46e5", marginBottom: "0.5rem" }}
+              />
+              <h3 style={{ margin: "0.5rem", display: "inline" }}>
+                Formulário de Matemática
+              </h3>
+            </div>
+            <div style={{ flex: 1, minWidth: "300px" }}>
+              <p>
+                Este formulário aborda tópicos básicos de matemática para
+                reforçar o aprendizado do aluno.
+              </p>
+              <ul style={{ margin: "0.5rem 2rem" }}>
+                <li>Operações aritméticas</li>
+                <li>Problemas de geometria simples</li>
+                <li>Interpretação de gráficos</li>
+                <li>Raciocínio numérico</li>
+              </ul>
+            </div>
+            <div style={{ marginLeft: "1rem", width: "200px" }}>
+              <Button onClick={() => navigate("/forms/math")}>Ir para o formulário de Matemática</Button>
+            </div>
+          </div>
         </li>
         <li>
-          <Button disabled>Formulário de Português</Button>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              flexWrap: "wrap",
+              border: "1px solid #4f46e5cc",
+              padding: "1rem",
+              borderRadius: "8px",
+              margin: "3rem 0",
+            }}
+          >
+            <div
+              style={{
+                textAlign: "center",
+                display: "flex",
+                flexDirection: "row",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "100%",
+                gap: "1rem",
+                margin: "1rem 0",
+              }}
+            >
+              <FormIcon
+                size={40}
+                style={{ color: "#4f46e5", marginBottom: "0.5rem" }}
+              />
+              <h3 style={{ margin: "0.5rem", display: "inline" }}>
+                Formulário de Português
+              </h3>
+            </div>
+            <div style={{ flex: 1, minWidth: "300px" }}>
+              <p>
+                Questões focadas em interpretação de texto e gramática para
+                avaliar o domínio da língua.
+              </p>
+              <ul style={{ margin: "0.5rem 2rem" }}>
+                <li>Compreensão de leitura</li>
+                <li>Ortografia e acentuação</li>
+                <li>Classes gramaticais</li>
+                <li>Análise sintática básica</li>
+              </ul>
+            </div>
+            <div style={{ marginLeft: "1rem", width: "200px" }}>
+              <Button onClick={() => navigate("/forms/portuguese")}>Ir para o formulário de Português</Button>
+            </div>
+          </div>
         </li>
       </ul>
       <div style={{ marginTop: "1rem" }}>

--- a/src/pages/MathForm.jsx
+++ b/src/pages/MathForm.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import LogoutButton from "../components/LogoutButton";
+import FormLayout, { Form, Logo } from "../components/FormLayout";
+import Button from "../components/Button";
+
+const MathForm = () => {
+  return (
+    <FormLayout>
+      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
+      <h1 style={{ fontFamily: "'Edu TAS Beginner', cursive" }}>
+        Formulário de Matemática
+      </h1>
+      <Form>
+        <p>Este formulário virá de uma rota do backend.</p>
+        <Button disabled>Enviar</Button>
+        <LogoutButton />
+      </Form>
+    </FormLayout>
+  );
+};
+
+export default MathForm;

--- a/src/pages/PortugueseForm.jsx
+++ b/src/pages/PortugueseForm.jsx
@@ -1,0 +1,22 @@
+import React from "react";
+import LogoutButton from "../components/LogoutButton";
+import FormLayout, { Form, Logo } from "../components/FormLayout";
+import Button from "../components/Button";
+
+const PortugueseForm = () => {
+  return (
+    <FormLayout>
+      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
+      <h1 style={{ fontFamily: "'Edu TAS Beginner', cursive" }}>
+        Formulário de Português
+      </h1>
+      <Form>
+        <p>Este formulário virá de uma rota do backend.</p>
+        <Button disabled>Enviar</Button>
+        <LogoutButton />
+      </Form>
+    </FormLayout>
+  );
+};
+
+export default PortugueseForm;


### PR DESCRIPTION
## Summary
- add MathForm and PortugueseForm pages
- link new form pages in router
- update home page with links to new forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cdc1f54c8832abe2c4b54b2e34a49