### PR TITLE
Add student user menu

### DIFF
--- a/src/components/UserMenu.jsx
+++ b/src/components/UserMenu.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import LogoutButton from "./LogoutButton";
+
+const Wrapper = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const Trigger = styled.button`
+  background: transparent;
+  border: none;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+`;
+
+const Dropdown = styled.div`
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  padding: 0.5rem;
+  z-index: 10;
+`;
+
+const UserIcon = ({ size = 24, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    width={size}
+    height={size}
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}
+  >
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+const UserMenu = ({ name }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Wrapper>
+      <Trigger onClick={() => setOpen((o) => !o)}>
+        <UserIcon />
+        <span>{name}</span>
+      </Trigger>
+      {open && (
+        <Dropdown>
+          <LogoutButton />
+        </Dropdown>
+      )}
+    </Wrapper>
+  );
+};
+
+export default UserMenu;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
 import Button from "../components/Button";
-import LogoutButton from "../components/LogoutButton";
+import UserMenu from "../components/UserMenu";
 import DoubleDiagonalBanner from "../components/DoubleDiagonalBanner";
 import FormIcon from "../components/FormIcon";
 import { useNavigate } from "react-router-dom";
@@ -18,7 +18,9 @@ const Banner = styled.div`
   background: linear-gradient(135deg, #4f46e5, #6b5ce7, #8b5cf6);
   color: #fff;
   padding: 4rem 2rem;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   clip-path: polygon(0 0, 100% 0, 100% 70%, 0 100%);
   margin: -2rem -2rem 2rem;
 `;
@@ -27,6 +29,8 @@ const Title = styled.h1`
   font-size: 2.5rem;
   font-family: "Edu TAS Beginner", cursive;
   margin: 0;
+  flex: 1;
+  text-align: center;
 `;
 
 const Intro = styled.div`
@@ -45,10 +49,13 @@ const IntroImage = styled.img`
 
 const Home = () => {
   const navigate = useNavigate();
+  const userData = JSON.parse(localStorage.getItem("userData") || "{}");
+  const name = userData.nome || "Aluno";
 
   return (
     <Container>
       <Banner>
+        <UserMenu name={name} />
         <Title>Orienta</Title>
       </Banner>
       <Intro>
@@ -245,9 +252,6 @@ const Home = () => {
           </div>
         </li>
       </ul>
-      <div style={{ marginTop: "1rem" }}>
-        <LogoutButton />
-      </div>
     </Container>
   );
 };


### PR DESCRIPTION
## Summary
- add a UserMenu component containing a user icon and logout dropdown
- show the logged student's name in the banner via UserMenu
- remove the standalone logout button from Home

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cde0d05c8832aa759cccbf8ddf263