### PR TITLE
Integrate questionnaire into logic form

### DIFF
--- a/src/pages/LogicForm.jsx
+++ b/src/pages/LogicForm.jsx
@@ -1,22 +1,8 @@
-import React from "react";
-import LogoutButton from "../components/LogoutButton";
-import FormLayout, { Form, Logo } from "../components/FormLayout";
-import Button from "../components/Button";
+import Questionario from "./Questionario";
 
 const LogicForm = () => {
-  return (
-    <FormLayout>
-      <Logo src="/image/gato.webp" alt="Logo do Projeto" />
-      <h1 style={{ fontFamily: "'Edu TAS Beginner', cursive" }}>
-        Formulário de Lógica
-      </h1>
-      <Form>
-        <p>Este formulário virá de uma rota do backend.</p>
-        <Button disabled>Enviar</Button>
-        <LogoutButton />
-      </Form>
-    </FormLayout>
-  );
+  return <Questionario />;
 };
 
 export default LogicForm;
+

--- a/src/pages/Questionario.jsx
+++ b/src/pages/Questionario.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from "react";
+import styled from "styled-components";
+import Button from "../components/Button";
+import UserMenu from "../components/UserMenu";
+import Loader from "../components/Loader";
+
+const Container = styled.div`
+  padding: 2rem;
+  min-height: 100vh;
+  font-family: "Inter", sans-serif;
+  background: "#fff";
+  color: #000;
+`;
+
+const Banner = styled.div`
+  background: linear-gradient(135deg, #4f46e5, #6b5ce7, #8b5cf6);
+  color: #fff;
+  padding: 4rem 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  clip-path: polygon(0 0, 100% 0, 100% 70%, 0 100%);
+  margin: -2rem -2rem 2rem;
+`;
+
+const Title = styled.h1`
+  font-size: 2.5rem;
+  font-family: "Edu TAS Beginner", cursive;
+  margin: 0;
+  flex: 1;
+  text-align: center;
+`;
+
+const QuestionWrapper = styled.div`
+  margin-bottom: 1.5rem;
+`;
+
+const Options = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+`;
+
+const Questionario = () => {
+  const [questions, setQuestions] = useState([]);
+  const [answers, setAnswers] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const userData = JSON.parse(localStorage.getItem("userData") || "{}");
+  const name = userData.nome || "Aluno";
+  const token = userData.token || "";
+
+  useEffect(() => {
+    fetch("https://code-race-qfh4.onrender.com/questionario", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error("Erro ao buscar question\u00e1rio");
+        return res.json();
+      })
+      .then((data) => {
+        const qs =
+          data.perguntas || data.questoes || data.questions || data || [];
+        setQuestions(Array.isArray(qs) ? qs : []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError("Erro ao carregar question\u00e1rio");
+        setLoading(false);
+      });
+  }, []);
+
+  const handleChange = (qIndex, value) => {
+    setAnswers((prev) => ({ ...prev, [qIndex]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    console.log(answers);
+  };
+
+  return (
+    <Container>
+      <Banner>
+        <UserMenu name={name} />
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <img src="/image/logo.png" alt="Logo Orienta" style={{ height: "60px" }} />
+          <Title style={{ flex: "unset" }}>Orienta</Title>
+        </div>
+      </Banner>
+      {loading && <Loader />}
+      {error && <p>{error}</p>}
+      {!loading && !error && (
+        <form onSubmit={handleSubmit} style={{ maxWidth: "800px", margin: "0 auto" }}>
+          {questions.map((q, index) => (
+            <QuestionWrapper key={q.id || index}>
+              <p>{q.enunciado || q.pergunta || q.titulo}</p>
+              <Options>
+                {(q.opcoes || q.alternativas || []).map((opt, idx) => {
+                  const value = opt.id ?? idx;
+                  const label = opt.texto || opt;
+                  return (
+                    <label key={value} style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
+                      <input
+                        type="radio"
+                        name={`q-${index}`}
+                        value={value}
+                        checked={answers[index] === value}
+                        onChange={() => handleChange(index, value)}
+                      />
+                      {label}
+                    </label>
+                  );
+                })}
+              </Options>
+            </QuestionWrapper>
+          ))}
+          {questions.length > 0 && (
+            <Button type="submit" style={{ marginTop: "1rem" }}>
+              Enviar
+            </Button>
+          )}
+        </form>
+      )}
+    </Container>
+  );
+};
+
+export default Questionario;


### PR DESCRIPTION
## Summary
- load Questionario page when visiting logic form route
- remove unused /forms/questionario route
- add Authorization header when fetching questionnaire

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ce8aa0b10832a84855da2f35ac36e