### PR TITLE
Support required answer payload format

### DIFF
--- a/src/pages/Questionario.jsx
+++ b/src/pages/Questionario.jsx
@@ -45,6 +45,7 @@ const Options = styled.div`
 const Questionario = () => {
   const [questions, setQuestions] = useState([]);
   const [answers, setAnswers] = useState({});
+  const [formSlug, setFormSlug] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -65,6 +66,7 @@ const Questionario = () => {
       .then((data) => {
         const qs =
           data.perguntas || data.questoes || data.questions || data || [];
+        setFormSlug(data.slug || "");
         setQuestions(Array.isArray(qs) ? qs : []);
         setLoading(false);
       })
@@ -81,6 +83,11 @@ const Questionario = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      const respostas = questions.map((q, index) => ({
+        slug: q.slug || q.id || index,
+        letraEscolhida: answers[index],
+      })).filter((r) => r.letraEscolhida !== undefined);
+      const payload = { slug: formSlug, respostas };
       const response = await fetch(
         "https://code-race-qfh4.onrender.com/questionario/responder",
         {
@@ -89,7 +96,7 @@ const Questionario = () => {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify(answers),
+          body: JSON.stringify(payload),
         }
       );
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- add `formSlug` state to remember quiz identifier
- send answers in `{ slug, respostas }` structure when submitting

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684cefd0b0c8832aabfc39a5c5227da2