### PR TITLE
Fix CORS via API proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_OPENAI_API_KEY=YOUR_API_KEY
+VITE_API_BASE_URL=https://code-race-qfh4.onrender.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # CodeRace 2025 Frontend
 
-Este projeto é uma aplicação React construída com Vite. Ele contém um formulário de login simples e algumas páginas utilizadas no evento CodeRace 2025. O formulário de login se autentica no backend disponível em `https://code-race-qfh4.onrender.com/auth`.
+Este projeto é uma aplicação React construída com Vite. Ele contém um formulário de login simples e algumas páginas utilizadas no evento CodeRace 2025. O formulário de login se autentica no backend disponível em `https://code-race-qfh4.onrender.com`.
+
+Para facilitar o desenvolvimento sem problemas de CORS, todas as requisições para a API são feitas através do caminho `/api`. O Vite realiza o proxy dessas rotas para o backend real durante o desenvolvimento e o arquivo `vercel.json` faz a reescrita em produção. O endereço do backend pode ser configurado pela variável `VITE_API_BASE_URL`.
 
 ## Exemplo de credenciais de login
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default [
     files: ['**/*.{js,jsx}'],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser,
+      globals: { ...globals.browser, process: 'readonly' },
       parserOptions: {
         ecmaVersion: 'latest',
         ecmaFeatures: { jsx: true },

--- a/src/__tests__/Register.test.jsx
+++ b/src/__tests__/Register.test.jsx
@@ -57,7 +57,7 @@ describe('Register page', () => {
     await user.type(screen.getByPlaceholderText(/confirme sua senha/i), '123456');
     await user.click(screen.getByRole('button', { name: /cadastrar/i }));
     expect(globalThis.fetch).toHaveBeenCalledWith(
-      'https://code-race-qfh4.onrender.com/usuario',
+      '/api/usuario',
       expect.objectContaining({ method: 'POST' })
     );
     expect(mockNavigate).not.toHaveBeenCalled();

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -7,6 +7,8 @@ import FormLayout, { Form, Logo } from "../components/FormLayout";
 import Toast from "../components/Toast";
 import { useNavigate, Link, useLocation } from "react-router-dom";
 
+const API_BASE_URL = process.env.VITE_API_BASE_URL || "/api";
+
 const ErrorMessage = styled.p`
   color: red;
   text-align: center;
@@ -95,7 +97,7 @@ const Login = () => {
     setError("");
     setLoading(true);
     try {
-      const response = await fetch("https://code-race-qfh4.onrender.com/auth", {
+      const response = await fetch(`${API_BASE_URL}/auth`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email, senha: password }),

--- a/src/pages/Questionario.jsx
+++ b/src/pages/Questionario.jsx
@@ -5,6 +5,8 @@ import UserMenu from "../components/UserMenu";
 import Loader from "../components/Loader";
 import { evaluateStudent } from "../services/gpt";
 
+const API_BASE_URL = process.env.VITE_API_BASE_URL || "/api";
+
 const Container = styled.div`
   padding: 2rem;
   min-height: 100vh;
@@ -46,7 +48,6 @@ const Options = styled.div`
 const Questionario = () => {
   const [questions, setQuestions] = useState([]);
   const [answers, setAnswers] = useState({});
-  const [formSlug, setFormSlug] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [feedback, setFeedback] = useState(null);
@@ -56,7 +57,7 @@ const Questionario = () => {
   const token = userData.token || "";
 
   useEffect(() => {
-    fetch("https://code-race-qfh4.onrender.com/questionario", {
+    fetch(`${API_BASE_URL}/questionario`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -68,7 +69,6 @@ const Questionario = () => {
       .then((data) => {
         const qs =
           data.perguntas || data.questoes || data.questions || data || [];
-        setFormSlug(data.slug || "");
         setQuestions(Array.isArray(qs) ? qs : []);
         setLoading(false);
       })
@@ -92,17 +92,14 @@ const Questionario = () => {
         }))
         .filter((r) => r.letraEscolhida !== undefined);
       const payload = { respostas };
-      const response = await fetch(
-        "https://code-race-qfh4.onrender.com/questionario/responder",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify(payload),
-        }
-      );
+      const response = await fetch(`${API_BASE_URL}/questionario/responder`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      });
       if (!response.ok) {
         throw new Error("Erro ao enviar respostas");
       }

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -6,6 +6,8 @@ import Button from "../components/Button";
 import FormLayout, { Form, Logo } from "../components/FormLayout";
 import { useNavigate } from "react-router-dom";
 
+const API_BASE_URL = process.env.VITE_API_BASE_URL || "/api";
+
 const ErrorMessage = styled.p`
   color: red;
   text-align: center;
@@ -102,14 +104,11 @@ const Register = () => {
     if (!validate()) return;
     setLoading(true);
     try {
-      const response = await fetch(
-        "https://code-race-qfh4.onrender.com/usuario",
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ nome, email, senha, tipoUsuario }),
-        }
-      );
+      const response = await fetch(`${API_BASE_URL}/usuario`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nome, email, senha, tipoUsuario }),
+      });
       if (!response.ok) {
         throw new Error("Erro ao cadastrar");
       }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "https://code-race-qfh4.onrender.com/$1" },
+    { "source": "/(.*)", "destination": "/" }
+  ]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,9 +4,21 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: process.env.VITE_API_BASE_URL || 'https://code-race-qfh4.onrender.com',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '')
+      }
+    }
+  },
   define: {
     'process.env.VITE_OPENAI_API_KEY': JSON.stringify(
       process.env.VITE_OPENAI_API_KEY || ''
+    ),
+    'process.env.VITE_API_BASE_URL': JSON.stringify(
+      process.env.VITE_API_BASE_URL || 'https://code-race-qfh4.onrender.com'
     )
   }
 })


### PR DESCRIPTION
## Summary
- proxy API requests through `/api` to avoid CORS errors
- expose `VITE_API_BASE_URL` in `.env.example`
- document proxy usage and environment variable
- allow `process` global in eslint
- update fetch URLs in pages and tests
- configure Vercel rewrites

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684cfc54f144832aa6988bba175da58e