### PR TITLE
Fix gauge clipping

### DIFF
--- a/src/components/ScoreGauge.jsx
+++ b/src/components/ScoreGauge.jsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 
 const Svg = styled.svg`
   display: block;
+  overflow: visible;
 `;
 
 const ScoreText = styled.text`


### PR DESCRIPTION
## Summary
- prevent score gauge from clipping its stroke

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d0ec69a10832a9955e800a8f92432