### PR TITLE
Fix gauge overflow bug

### DIFF
--- a/src/components/ScoreGauge.jsx
+++ b/src/components/ScoreGauge.jsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 
 const Svg = styled.svg`
   display: block;
-  overflow: visible;
+  overflow: hidden;
 `;
 
 const ScoreText = styled.text`


### PR DESCRIPTION
## Summary
- adjust ScoreGauge's SVG overflow setting to avoid the colored arc overflowing its container

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d0febc64c832a92231fb20ed3c3bf