### PR TITLE
Add teacher advice summary

### DIFF
--- a/src/__tests__/teacherAdvice.test.js
+++ b/src/__tests__/teacherAdvice.test.js
@@ -1,0 +1,28 @@
+import { teacherAdvice } from '../services/gpt';
+
+describe('teacherAdvice', () => {
+  beforeEach(() => {
+    globalThis.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns advice text from OpenAI', async () => {
+    const responseBody = {
+      choices: [
+        { message: { content: 'ajude o aluno com matemática' } },
+      ],
+    };
+    globalThis.fetch.mockResolvedValue({ ok: true, json: async () => responseBody });
+
+    const result = await teacherAdvice({ nome: 'Bob' });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result).toBe('ajude o aluno com matemática');
+  });
+});

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,8 @@ import LogoutButton from "../components/LogoutButton";
 import UserMenu from "../components/UserMenu";
 import ScoreGauge from "../components/ScoreGauge";
 import EyeIcon from "../components/EyeIcon";
+import Button from "../components/Button";
+import { teacherAdvice } from "../services/gpt";
 
 const API_BASE_URL = process.env.VITE_API_BASE_URL || "/api";
 
@@ -55,12 +57,25 @@ const Dashboard = () => {
   const [students, setStudents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState({});
+  const [advice, setAdvice] = useState({});
   const userData = JSON.parse(localStorage.getItem("userData") || "{}");
   const name = userData.nome || "Professor";
   const token = userData.token || "";
 
   const toggleRow = (index) => {
     setExpanded((prev) => ({ ...prev, [index]: !prev[index] }));
+  };
+
+  const getAdvice = async (index) => {
+    const student = students[index];
+    if (!student) return;
+    setAdvice((prev) => ({ ...prev, [index]: { loading: true } }));
+    try {
+      const text = await teacherAdvice(student);
+      setAdvice((prev) => ({ ...prev, [index]: { text } }));
+    } catch (e) {
+      setAdvice((prev) => ({ ...prev, [index]: { text: "Erro ao obter resumo" } }));
+    }
   };
 
   useEffect(() => {
@@ -173,6 +188,17 @@ const Dashboard = () => {
                         ) : (
                           <em>Nenhum resultado</em>
                         )}
+                        <div style={{ marginTop: "0.5rem" }}>
+                          <Button onClick={() => getAdvice(idx)}>
+                            Resumo de como ajudar
+                          </Button>
+                          {advice[idx]?.loading && (
+                            <span style={{ marginLeft: "0.5rem" }}>Carregando...</span>
+                          )}
+                          {advice[idx]?.text && (
+                            <p style={{ marginTop: "0.5rem" }}>{advice[idx].text}</p>
+                          )}
+                        </div>
                       </Td>
                     </tr>
                   )}

--- a/src/services/gpt.js
+++ b/src/services/gpt.js
@@ -59,3 +59,45 @@ export async function evaluateStudent(resultData) {
     return { feedback: content };
   }
 }
+
+export async function teacherAdvice(studentData) {
+  const apiKey =
+    "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";
+
+  if (!apiKey) {
+    throw new Error("OpenAI API key not provided");
+  }
+
+  const messages = [
+    {
+      role: "system",
+      content:
+        "Você é um pedagogo. Responda em português em até 3 frases de como o professor pode ajudar o aluno a melhorar.",
+    },
+    {
+      role: "user",
+      content: `Dados do aluno: ${JSON.stringify(studentData)}. Gere um breve resumo sobre como o professor pode auxiliar o aluno a evoluir.`,
+    },
+  ];
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: "gpt-4-turbo",
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Erro da OpenAI:", errorText);
+    throw new Error("Erro ao consultar ChatGPT");
+  }
+
+  const data = await response.json();
+  return data.choices?.[0]?.message?.content || "";
+}


### PR DESCRIPTION
## Summary
- create a `teacherAdvice` service to fetch a brief summary from ChatGPT
- show button on Dashboard to generate advice for each student
- test the new service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d1d954b6c832a804512dfcae14f80